### PR TITLE
Fix: let curl fail when returning 4xx http codes

### DIFF
--- a/backport/backport.py
+++ b/backport/backport.py
@@ -19,7 +19,8 @@ import os
 import subprocess
 import sys
 
-# NOTE: Replace this with your own toekn
+# NOTE: Replace this with your own token, which must be a classic token that
+# has public_repo scope enabled to be able to mark the backported PRs as done.
 BEARER_TOKEN = "ghp_???"
 # NOTE: Replace this with your own GitHub username
 USERNAME = "TrueBrain"
@@ -71,6 +72,7 @@ def do_query(query, variables):
     res = subprocess.run(
         [
             "curl",
+            "--fail",
             "-H",
             f"Authorization: bearer {BEARER_TOKEN}",
             "-X",
@@ -90,6 +92,7 @@ def do_remove_label(number):
     return subprocess.run(
         [
             "curl",
+            "--fail",
             "-H",
             f"Authorization: bearer {BEARER_TOKEN}",
             "-X",
@@ -104,6 +107,7 @@ def do_add_label(number):
     return subprocess.run(
         [
             "curl",
+            "--fail",
             "-H",
             f"Authorization: bearer {BEARER_TOKEN}",
             "-X",


### PR DESCRIPTION
### Reason

`backport.py --mark-done` not working, but seeming to be all right (no errors).
Expectation is either an error, or doing the right thing.

### Description

Add `--fail` to curl commands and hint in the comment that some particular scopes must be selected for the `--mark-done` functionality.