### PR TITLE
Fix: don't crash when backporting non-merged PRs

### DIFF
--- a/backport/backport.py
+++ b/backport/backport.py
@@ -173,6 +173,11 @@ def main():
         print("ERROR: couldn't fetch all Pull Requests marked for 'backport requested'")
         return
 
+    for pr in all_prs["data"]["search"]["edges"]:
+        if pr["node"]["mergedAt"] is None:
+            print(f"ERROR: #{pr['node']['number']} is marked for 'backport requested' while not merged")
+            return
+
     if not resume:
         do_command(["git", "fetch", "upstream"])
         do_command(["git", "checkout", f"upstream/release/{RELEASE}", "-B", "release-backport"])


### PR DESCRIPTION
Adding `backport requested` on an open PR and forgetting to removed it when the PR is closed without merging may happen.
And this crashes the backport script.

Detect the issue and inform user instead of crashing.